### PR TITLE
feat: add support for binary format

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,8 +90,10 @@ calling the `opts.skip()` method from within this definition will allow the defa
 
 #### `opts.transform`
 
-Configure whether to transform the output patch into `minify` or `maximize`, by default all inbuilt operations
-return minified patches, but user defined diffs may not
+Configure whether to transform the output patch into `minify`, `maximize` or `serialize`, by default all inbuilt operations
+return minified patches, but user defined diffs may not.
+
+If the user wishes to use `serialize`, the optional `bson` dependency is required for both serialize and deserialize
 
 </details>
 
@@ -123,8 +125,10 @@ calling the `opts.skip()` method from within this definition will allow the defa
 
 #### `opts.transform`
 
-Configure whether to transform the output patch into `minify` or `maximize`, by default all inbuilt operations
-return minified patches, but user defined diffs may not
+Configure whether to transform the output patch into `minify`, `maximize` or `serialize`, by default all inbuilt operations
+return minified patches, but user defined diffs may not.
+
+If the user wishes to use `serialize`, the optional `bson` dependency is required for both serialize and deserialize
 
 </details>
 

--- a/package.json
+++ b/package.json
@@ -41,6 +41,14 @@
     "validate": "attw --pack"
   },
   "types": "./dist/index.d.mts",
+  "peerDependencies": {
+    "bson": "*"
+  },
+  "peerDependenciesMeta": {
+    "bson": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.17.4",
     "@rollup/plugin-terser": "^0.4.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,10 @@ settings:
 importers:
 
   .:
+    dependencies:
+      bson:
+        specifier: '*'
+        version: 6.10.3
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: ^0.17.4
@@ -825,6 +829,10 @@ packages:
     resolution: {integrity: sha512-btwCFJVjI4YWDNfau8RhZ+B1Q/VLoUITrm3RlP6y1tYGWIOa+InuYiRGXUBXo8nA1qKmHMyLB/iVQg5TT4eFoA==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
+
+  bson@6.10.3:
+    resolution: {integrity: sha512-MTxGsqgYTwfshYWTRdmZRC+M7FnG1b4y7RO7p2k3X24Wq0yv1m77Wsj0BzlPzd/IowgESfsruQCUToa7vbOpPQ==}
+    engines: {node: '>=16.20.1'}
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
@@ -3299,6 +3307,8 @@ snapshots:
       electron-to-chromium: 1.5.14
       node-releases: 2.0.18
       update-browserslist-db: 1.1.0(browserslist@4.23.3)
+
+  bson@6.10.3: {}
 
   buffer-from@1.1.2: {}
 

--- a/src/create.ts
+++ b/src/create.ts
@@ -1,5 +1,5 @@
 import { diff } from './diff';
-import { Maxi, maximize, Mini, minify, Patch } from './patch';
+import { Maxi, maximize, Mini, minify, Patch, serialize } from './patch';
 import { RootPointer } from './pointer';
 import { CreateOpts } from './utils';
 
@@ -57,7 +57,26 @@ export function create(input: any, output: any, opts: CreateOpts & { transform: 
  * For array transformations we attempt to reduce the size of operations by running an edit distance style algorithm,
  * with support for `add`, `remove`, `replace`, `copy`, `array replace` operations.
  *
+ * The output will be a {@link Uint8Array patch}
+ *
+ * @param input - The input to compare from
+ * @param output - The output to compare to
+ * @param opts - options for custom handling
+ * @param opts.transform - force the output to be serialized
+ */
+export function create(input: any, output: any, opts: CreateOpts & { transform: 'serialize' }): Uint8Array | null;
+/**
+ * Returns a list of operations (a JSON Patch) comprised of the operations to transform `input` into `output`.
+ * It attempts to produce the smallest patch, this does not necessarily mean the smallest number of operations,
+ * as a full replacement may result in more bytes being sent.
+ *
+ * For array transformations we attempt to reduce the size of operations by running an edit distance style algorithm,
+ * with support for `add`, `remove`, `replace`, `copy`, `array replace` operations.
+ *
  * The output will be a {@link Patch}
+ *
+ * If the user provided {@link Differ} returns a Serialized patch,
+ * it will be converted to a {@link Mini.Patch} and then combined with the other patches
  *
  * @param input - The input to compare from
  * @param output - The output to compare to
@@ -84,5 +103,6 @@ export function create(input: any, output: any, opts: CreateOpts = {}): Patch | 
 
   if (opts?.transform === 'minify') return minify(patch);
   if (opts?.transform === 'maximize') return maximize(patch);
+  if (opts?.transform === 'serialize') return serialize(patch);
   return patch;
 }

--- a/src/diff.ts
+++ b/src/diff.ts
@@ -88,6 +88,28 @@ export function diff(input: any, output: any, ptr: Pointer, opts: DiffOpts & { t
  * For array transformations we attempt to reduce the size of operations by running an edit distance style algorithm,
  * with support for `add`, `remove`, `replace`, `copy`, `array replace` operations.
  *
+ * The output will be a {@link Uint8Array patch}
+ *
+ * @param input - The input to compare from
+ * @param output - The output to compare to
+ * @param ptr - Pointer representing the current position relative to the input root
+ * @param opts - options for custom handling
+ * @param opts.transform - force the output to be serialized
+ */
+export function diff(
+  input: unknown,
+  output: unknown,
+  ptr: Pointer,
+  opts: DiffOpts & { transform: 'serialize' },
+): Uint8Array;
+/**
+ * Returns a list of operations (a JSON Patch) comprised of the operations to transform `input` into `output`.
+ * It attempts to produce the smallest patch, this does not necessarily mean the smallest number of operations,
+ * as a full replacement may result in more bytes being sent.
+ *
+ * For array transformations we attempt to reduce the size of operations by running an edit distance style algorithm,
+ * with support for `add`, `remove`, `replace`, `copy`, `array replace` operations.
+ *
  * The output will be a {@link Patch} if the user provided {@link Differ} returns a Serialized patch,
  * it will be converted to a {@link Mini.Patch} and then combined with the other patches
  *

--- a/src/error.ts
+++ b/src/error.ts
@@ -36,3 +36,7 @@ export class InvalidPatchError extends Error {
     super(`Invalid patch: '${patch}'`);
   }
 }
+
+export class UnserializableError extends Error {
+  name = 'UnserializableError';
+}

--- a/src/utils/bson.test.ts
+++ b/src/utils/bson.test.ts
@@ -1,0 +1,10 @@
+import { test, vi } from 'vitest';
+import { deserializeBSON, serializeBSON } from './bson';
+
+// Effectively unload bson from the loaded modules
+vi.mock('bson', async () => ({ default: undefined, serialize: undefined, deserialize: undefined }));
+
+test('error on bson missing', ({ expect }) => {
+  expect(() => serializeBSON({})).toThrow(ReferenceError);
+  expect(() => deserializeBSON(new Uint8Array())).toThrow(ReferenceError);
+});

--- a/src/utils/bson.ts
+++ b/src/utils/bson.ts
@@ -1,0 +1,13 @@
+// Allow bson to be installed optionally and make it work on all platforms
+const { serialize, deserialize } = require('bson');
+
+export const serializeBSON: typeof serialize = function () {
+  if (!serialize) throw new ReferenceError("Serialization requires 'bson' to be installed");
+  // eslint-disable-next-line prefer-rest-params
+  return serialize(...arguments);
+};
+export const deserializeBSON: typeof deserialize = function () {
+  if (!deserialize) throw new ReferenceError("Deserialization requires 'bson' to be installed");
+  // eslint-disable-next-line prefer-rest-params
+  return deserialize(...arguments);
+};

--- a/src/utils/transform.ts
+++ b/src/utils/transform.ts
@@ -1,12 +1,14 @@
-import { Maxi, maximize, Mini, minify, Patch } from '../patch';
+import { Maxi, maximize, Mini, minify, Patch, serialize } from '../patch';
 import { Transformer } from './types';
 
 export function transform(patch: Patch, transform: 'minify'): Mini.Patch;
 export function transform(patch: Patch, transform: 'maximize'): Maxi.Patch;
+export function transform(patch: Patch, transform: 'serialize'): Uint8Array;
 export function transform<T extends Patch>(patch: T, transform?: Transformer): T;
 export function transform(patch: Patch, transform?: Transformer): Patch {
   if (!transform) return patch;
   if (transform === 'minify') return minify(patch);
   if (transform === 'maximize') return maximize(patch);
+  if (transform === 'serialize') return serialize(patch);
   return patch;
 }

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -3,7 +3,7 @@ import { Pointer } from '../pointer';
 
 export type CloneOpts = { clone?: Cloner };
 export type EqOpts = { eq?: EqFunc };
-export type Transformer = 'minify' | 'maximize';
+export type Transformer = 'minify' | 'maximize' | 'serialize';
 type TransformOpts = { transform?: Transformer };
 export type DiffOpts = EqOpts & CloneOpts & TransformOpts & { diff?: Differ };
 export type CreateOpts = DiffOpts;


### PR DESCRIPTION
Adds support for a highly compressed binary format of the patch.

If you think this should be added let me know, unfortunately it makes the built package much larger (from 182Kb to 695Kb). If there is a demand for this I will include it, otherwise it can stay here as a PR